### PR TITLE
Revert "3.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0]
-
-### Changed
-
-- **BREAKING:** Changed package name from "@metamask/snap-watch-only" to "@metamask/account-watcher"
-- Updated form design and copy
-
 ## [2.0.0]
 
 ### Changed
@@ -26,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: git+https://github.com/metamask/snap-watch-only/compare/v3.0.0...HEAD
-[3.0.0]: git+https://github.com/metamask/snap-watch-only/compare/v2.0.0...v3.0.0
+[Unreleased]: git+https://github.com/metamask/snap-watch-only/compare/v2.0.0...HEAD
 [2.0.0]: git+https://github.com/metamask/snap-watch-only/compare/v1.0.0...v2.0.0
 [1.0.0]: git+https://github.com/metamask/snap-watch-only/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/account-watcher",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "Keep an eye on Ethereum accounts right in MetaMask",
   "keywords": [
     "metamask",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "Keep an eye on Ethereum addresses or ENS domains right in MetaMask",
   "proposedName": "Account Watcher",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "CXyJv8X2snsa9yDqedgcGZXQy4xxuJkMqu3k5zB+NaE=",
+    "shasum": "/L3CSLS+JgceT5pLKZgXchkYIR9RoBRFCUQPG27OIGk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
Reverts MetaMask/snap-watch-only#18

release job is still failing due to `Error: process.env.REPOSITORY_URL must be a valid URL.` so we will cut a new release with the url fixed.