### PR TITLE
fix: publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,7 +34,7 @@ jobs:
         id: restore-build
         with:
           path: |
-            ./packages/*/dist
+            ./dist
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
 
@@ -49,7 +49,7 @@ jobs:
         id: restore-build
         with:
           path: |
-            ./packages/*/dist
+            ./dist
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Dry Run Publish
@@ -73,7 +73,7 @@ jobs:
         id: restore-build
         with:
           path: |
-            ./packages/*/dist
+            ./dist
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,11 +16,11 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - uses: MetaMask/action-publish-release@v3
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - uses: actions/cache@v3
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - uses: actions/cache@v3
@@ -91,7 +91,7 @@ jobs:
     outputs:
       RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - id: get-release-version


### PR DESCRIPTION
## Description

Updated the publish release workflow to no longer look for `packages/*/dist` in monorepo structure but to publish the `./dist` folder directly.