### PR TITLE
fix: ens resolution only supported on mainnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ node_modules/
 # IntelliJ
 .idea/
 /.idea/
+
+# Testing site
+site/
+/site/

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "k3uPqA1yqVfGuO9FVLMrJ300SyIkRJzDfrahKC8TgDA=",
+    "shasum": "jDKW45/aCM/oZkMRngeI0G60Dxk96Zsxke3GqioMxgk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "jDKW45/aCM/oZkMRngeI0G60Dxk96Zsxke3GqioMxgk=",
+    "shasum": "9GSsDt2F+C27DmhZdjVz92aTRp6b9NzkWautlxpxLa0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "axNCjj2hVcJFJ9K7BM65w8Av6KqR9F+bVXv9i+mizqg=",
+    "shasum": "k3uPqA1yqVfGuO9FVLMrJ300SyIkRJzDfrahKC8TgDA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { originPermissions } from './permissions';
 import { getState } from './stateManagement';
 import { WatchFormNames } from './ui/components';
 import { createInterface, showErrorMessage, showSuccess } from './ui/ui';
-import { validateUserInput } from './ui/ui-utils';
+import { isMainnet, validateUserInput } from './ui/ui-utils';
 
 let keyring: WatchOnlyKeyring;
 
@@ -89,9 +89,13 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
     event.name === WatchFormNames.AddressForm
   ) {
     const inputValue = event.value[WatchFormNames.AddressInput];
+    const onMainnet = await isMainnet();
 
     if (!inputValue) {
-      await showErrorMessage(id, 'Address or ENS is required');
+      const emptyInputMessage = onMainnet
+        ? 'Address or ENS is required'
+        : 'Address is required';
+      await showErrorMessage(id, emptyInputMessage);
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,9 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
     event.name === WatchFormNames.AddressForm
   ) {
     const inputValue = event.value[WatchFormNames.AddressInput];
-    const onMainnet = await isMainnet();
 
     if (!inputValue) {
+      const onMainnet = await isMainnet();
       const emptyInputMessage = onMainnet
         ? 'Address or ENS is required'
         : 'Address is required';

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,12 +5,14 @@ export const TEST_VALUES = {
   smartContractAddress: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',
 };
 
+export const mockGetNetwork = jest.fn(async () => {
+  return { chainId: 1 };
+});
+
 // eslint-disable-next-line import/unambiguous
 jest.mock('ethers', () => {
   const BrowserProvider = jest.fn().mockImplementation((_ethereum) => ({
-    getNetwork: jest.fn().mockImplementation(async () => {
-      return Promise.resolve({ chainId: 1 });
-    }),
+    getNetwork: mockGetNetwork,
     getCode: jest.fn().mockImplementation(async (address) => {
       return Promise.resolve(
         address === TEST_VALUES.smartContractAddress ? '0x123' : '0x',

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,6 +8,9 @@ export const TEST_VALUES = {
 // eslint-disable-next-line import/unambiguous
 jest.mock('ethers', () => {
   const BrowserProvider = jest.fn().mockImplementation((_ethereum) => ({
+    getNetwork: jest.fn().mockImplementation(async () => {
+      return Promise.resolve({ chainId: 1 });
+    }),
     getCode: jest.fn().mockImplementation(async (address) => {
       return Promise.resolve(
         address === TEST_VALUES.smartContractAddress ? '0x123' : '0x',

--- a/src/ui/components.ts
+++ b/src/ui/components.ts
@@ -24,9 +24,11 @@ import {
 
 import {
   WATCH_FORM_DESCRIPTION,
+  WATCH_FORM_DESCRIPTION_MAINNET,
   WATCH_FORM_HEADER,
   WATCH_FORM_INPUT_LABEL,
   WATCH_FORM_INPUT_PLACEHOLDER,
+  WATCH_FORM_INPUT_PLACEHOLDER_MAINNET,
   WATCH_FORM_INSTRUCTIONS,
 } from './content';
 
@@ -39,16 +41,14 @@ export enum WatchFormNames {
 /**
  * Generate the watch form component.
  *
- * @param validationMessage - The validation message to display (if any).
+ * @param onMainnet - Whether the user is on the mainnet (default: false).
  * @returns The watch form component to display.
  */
-export function generateWatchFormComponent(
-  validationMessage?: string,
-): Component {
-  if (validationMessage) {
+export function generateWatchFormComponent(onMainnet?: boolean): Component {
+  if (onMainnet) {
     return panel([
       heading(WATCH_FORM_HEADER),
-      text(WATCH_FORM_DESCRIPTION),
+      text(WATCH_FORM_DESCRIPTION_MAINNET),
       text(WATCH_FORM_INSTRUCTIONS),
       form({
         name: WatchFormNames.AddressForm,
@@ -56,7 +56,7 @@ export function generateWatchFormComponent(
           input({
             name: WatchFormNames.AddressInput,
             label: WATCH_FORM_INPUT_LABEL,
-            placeholder: WATCH_FORM_INPUT_PLACEHOLDER,
+            placeholder: WATCH_FORM_INPUT_PLACEHOLDER_MAINNET,
           }),
           button({
             variant: ButtonVariant.Primary,
@@ -66,7 +66,6 @@ export function generateWatchFormComponent(
           }),
         ],
       }),
-      text(validationMessage),
     ]);
   }
   return panel([

--- a/src/ui/components.ts
+++ b/src/ui/components.ts
@@ -24,11 +24,10 @@ import {
 
 import {
   WATCH_FORM_DESCRIPTION,
-  WATCH_FORM_DESCRIPTION_MAINNET,
+  WATCH_FORM_ENS_DISCLAIMER,
   WATCH_FORM_HEADER,
   WATCH_FORM_INPUT_LABEL,
   WATCH_FORM_INPUT_PLACEHOLDER,
-  WATCH_FORM_INPUT_PLACEHOLDER_MAINNET,
   WATCH_FORM_INSTRUCTIONS,
 } from './content';
 
@@ -41,33 +40,9 @@ export enum WatchFormNames {
 /**
  * Generate the watch form component.
  *
- * @param onMainnet - Whether the user is on the mainnet (default: false).
  * @returns The watch form component to display.
  */
-export function generateWatchFormComponent(onMainnet?: boolean): Component {
-  if (onMainnet) {
-    return panel([
-      heading(WATCH_FORM_HEADER),
-      text(WATCH_FORM_DESCRIPTION_MAINNET),
-      text(WATCH_FORM_INSTRUCTIONS),
-      form({
-        name: WatchFormNames.AddressForm,
-        children: [
-          input({
-            name: WatchFormNames.AddressInput,
-            label: WATCH_FORM_INPUT_LABEL,
-            placeholder: WATCH_FORM_INPUT_PLACEHOLDER_MAINNET,
-          }),
-          button({
-            variant: ButtonVariant.Primary,
-            value: 'Watch account',
-            name: WatchFormNames.SubmitButton,
-            buttonType: ButtonType.Submit,
-          }),
-        ],
-      }),
-    ]);
-  }
+export function generateWatchFormComponent(): Component {
   return panel([
     heading(WATCH_FORM_HEADER),
     text(WATCH_FORM_DESCRIPTION),
@@ -88,6 +63,7 @@ export function generateWatchFormComponent(onMainnet?: boolean): Component {
         }),
       ],
     }),
+    text(WATCH_FORM_ENS_DISCLAIMER),
   ]);
 }
 

--- a/src/ui/content.ts
+++ b/src/ui/content.ts
@@ -1,6 +1,9 @@
 export const WATCH_FORM_HEADER = 'Watch any Ethereum account 👀';
 
 export const WATCH_FORM_DESCRIPTION =
+  'Enter any public address to add an account to watch within MetaMask.';
+
+export const WATCH_FORM_DESCRIPTION_MAINNET =
   'Enter any public address or ENS name to add an account to watch within MetaMask.';
 
 export const WATCH_FORM_INSTRUCTIONS =
@@ -8,5 +11,7 @@ export const WATCH_FORM_INSTRUCTIONS =
 
 export const WATCH_FORM_INPUT_LABEL = 'Ethereum address';
 
-export const WATCH_FORM_INPUT_PLACEHOLDER =
+export const WATCH_FORM_INPUT_PLACEHOLDER = 'Enter a public address';
+
+export const WATCH_FORM_INPUT_PLACEHOLDER_MAINNET =
   'Enter a public address or ENS name';

--- a/src/ui/content.ts
+++ b/src/ui/content.ts
@@ -1,17 +1,15 @@
 export const WATCH_FORM_HEADER = 'Watch any Ethereum account 👀';
 
 export const WATCH_FORM_DESCRIPTION =
-  'Enter any public address to add an account to watch within MetaMask.';
-
-export const WATCH_FORM_DESCRIPTION_MAINNET =
-  'Enter any public address or ENS name to add an account to watch within MetaMask.';
+  'Enter any public address or *ENS name to add an account to watch within MetaMask.';
 
 export const WATCH_FORM_INSTRUCTIONS =
   'The watched accounts will be listed alongside the rest of your accounts in a safe, watch-only mode. Remember, you can look but you can’t sign or transact.';
 
 export const WATCH_FORM_INPUT_LABEL = 'Ethereum address';
 
-export const WATCH_FORM_INPUT_PLACEHOLDER = 'Enter a public address';
-
-export const WATCH_FORM_INPUT_PLACEHOLDER_MAINNET =
+export const WATCH_FORM_INPUT_PLACEHOLDER =
   'Enter a public address or ENS name';
+
+export const WATCH_FORM_ENS_DISCLAIMER =
+  '*ENS names are only supported on Ethereum mainnet';

--- a/src/ui/ui-utils.test.ts
+++ b/src/ui/ui-utils.test.ts
@@ -3,7 +3,7 @@ import {
   isSmartContractAddress,
   validateUserInput,
 } from './ui-utils';
-import { TEST_VALUES } from '../test/setup';
+import { mockGetNetwork, TEST_VALUES } from '../test/setup';
 
 // @ts-expect-error Mocking ethereum global object
 global.ethereum = {
@@ -94,15 +94,11 @@ describe('UI Utils', () => {
         });
       });
 
-      // TODO: Fix this test
       it('should return ENS is only supported on Ethereum mainnet message', async () => {
-        jest.mock('./ui-utils', () => ({
-          ...jest.requireActual('./ui-utils'),
-          isMainnet: jest.fn().mockImplementation(async () => {
-            console.log('inside isMainnet mock');
-            return Promise.resolve(false);
-          }),
-        }));
+        // Override getNetwork to return a non-mainnet chainId here
+        mockGetNetwork.mockImplementationOnce(async () => {
+          return { chainId: 59144 }; // Custom or test network chain ID
+        });
 
         const result = await validateUserInput('something.eth');
         expect(result).toStrictEqual({

--- a/src/ui/ui-utils.test.ts
+++ b/src/ui/ui-utils.test.ts
@@ -96,12 +96,15 @@ describe('UI Utils', () => {
 
       // TODO: Fix this test
       it('should return ENS is only supported on Ethereum mainnet message', async () => {
-        jest.mock('./ui-utils', () => {
-          return {
-            isMainnet: jest.fn().mockResolvedValueOnce(false),
-          };
-        });
-        const result = await validateUserInput(TEST_VALUES.validEns);
+        jest.mock('./ui-utils', () => ({
+          ...jest.requireActual('./ui-utils'), // this line ensures other functions are still accessible as they originally were
+          isMainnet: jest.fn().mockImplementation(async () => {
+            console.log('inside isMainnet mock');
+            return Promise.resolve(false);
+          }),
+        }));
+
+        const result = await validateUserInput('something.eth');
         expect(result).toStrictEqual({
           message: 'ENS is only supported on Ethereum mainnet',
         });

--- a/src/ui/ui-utils.test.ts
+++ b/src/ui/ui-utils.test.ts
@@ -97,7 +97,7 @@ describe('UI Utils', () => {
       // TODO: Fix this test
       it('should return ENS is only supported on Ethereum mainnet message', async () => {
         jest.mock('./ui-utils', () => ({
-          ...jest.requireActual('./ui-utils'), // this line ensures other functions are still accessible as they originally were
+          ...jest.requireActual('./ui-utils'),
           isMainnet: jest.fn().mockImplementation(async () => {
             console.log('inside isMainnet mock');
             return Promise.resolve(false);

--- a/src/ui/ui-utils.test.ts
+++ b/src/ui/ui-utils.test.ts
@@ -93,6 +93,19 @@ describe('UI Utils', () => {
           message: 'Invalid ENS name',
         });
       });
+
+      // TODO: Fix this test
+      it('should return ENS is only supported on Ethereum mainnet message', async () => {
+        jest.mock('./ui-utils', () => {
+          return {
+            isMainnet: jest.fn().mockResolvedValueOnce(false),
+          };
+        });
+        const result = await validateUserInput(TEST_VALUES.validEns);
+        expect(result).toStrictEqual({
+          message: 'ENS is only supported on Ethereum mainnet',
+        });
+      });
     });
 
     describe('when input is invalid', () => {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -4,6 +4,7 @@ import {
   generateSuccessMessageComponent,
   generateWatchFormComponent,
 } from './components';
+import { isMainnet } from './ui-utils';
 
 /**
  * Initiate a new interface with the starting screen.
@@ -11,10 +12,11 @@ import {
  * @returns The Snap interface ID.
  */
 export async function createInterface(): Promise<string> {
+  const onMainnet = await isMainnet();
   return await snap.request({
     method: 'snap_createInterface',
     params: {
-      ui: generateWatchFormComponent(),
+      ui: generateWatchFormComponent(onMainnet),
     },
   });
 }
@@ -23,14 +25,14 @@ export async function createInterface(): Promise<string> {
  * Update the interface with the watch-only form containing an input and a submit button.
  *
  * @param id - The Snap interface ID to update.
- * @param validationMessage - The validation message to display.
  */
-export async function showForm(id: string, validationMessage?: string) {
+export async function showForm(id: string) {
+  const onMainnet = await isMainnet();
   await snap.request({
     method: 'snap_updateInterface',
     params: {
       id,
-      ui: generateWatchFormComponent(validationMessage),
+      ui: generateWatchFormComponent(onMainnet),
     },
   });
 }

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -4,7 +4,6 @@ import {
   generateSuccessMessageComponent,
   generateWatchFormComponent,
 } from './components';
-import { isMainnet } from './ui-utils';
 
 /**
  * Initiate a new interface with the starting screen.
@@ -12,11 +11,10 @@ import { isMainnet } from './ui-utils';
  * @returns The Snap interface ID.
  */
 export async function createInterface(): Promise<string> {
-  const onMainnet = await isMainnet();
   return await snap.request({
     method: 'snap_createInterface',
     params: {
-      ui: generateWatchFormComponent(onMainnet),
+      ui: generateWatchFormComponent(),
     },
   });
 }
@@ -27,12 +25,11 @@ export async function createInterface(): Promise<string> {
  * @param id - The Snap interface ID to update.
  */
 export async function showForm(id: string) {
-  const onMainnet = await isMainnet();
   await snap.request({
     method: 'snap_updateInterface',
     params: {
       id,
-      ui: generateWatchFormComponent(onMainnet),
+      ui: generateWatchFormComponent(),
     },
   });
 }


### PR DESCRIPTION
## Description

Only support ENS resolution when the user is on mainnet. Check currently selected chain ID in Snap homepage and notify the user that ENS is only available on mainnet. If user is not on mainnet, and inputs an ENS name, the snap will show the error message "ENS is only supported on Ethereum mainnet"

fixes: https://github.com/MetaMask/accounts-planning/issues/402

## Demo

https://github.com/MetaMask/snap-watch-only/assets/91970214/8e0b5111-291d-40c7-bf3e-c4e48befe239
