### PR TITLE
feat: remove success screen

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "9GSsDt2F+C27DmhZdjVz92aTRp6b9NzkWautlxpxLa0=",
+    "shasum": "dAJEkECdBj8RGcinrYAuCSIIUbPGK4+px6OdiLwZ3J0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,9 +102,6 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
     const validation = await validateUserInput(inputValue);
 
     if (validation.address) {
-      // Show success resolution message and add the account to the keyring
-      await showSuccess(id, validation.address, validation.message, true);
-      await new Promise((resolve) => setTimeout(resolve, 2000));
       try {
         await (
           await getKeyring()

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { WatchOnlyKeyring } from './keyring';
 import { originPermissions } from './permissions';
 import { getState } from './stateManagement';
 import { WatchFormNames } from './ui/components';
-import { createInterface, showErrorMessage, showSuccess } from './ui/ui';
+import { createInterface, showErrorMessage } from './ui/ui';
 import { isMainnet, validateUserInput } from './ui/ui-utils';
 
 let keyring: WatchOnlyKeyring;


### PR DESCRIPTION
## Description

Per this [Slack thread](https://consensys.slack.com/archives/C05FUV4205C/p1715277267472089) we are no longer going to show the success screen and instead redirect from "Watch account" button click directly to the page in the extension for the new account.