### PR TITLE
feat: account name suggestion

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "k2HANqGaxSqbBreFEi0M9a9oUpTRhDu5XMEnBOH/C5A=",
+    "shasum": "Q/Tx0ZWIkZy0Kr1Qi0s3DdGOCcH5+PGee9lX0p8Qj/E=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ let keyring: WatchOnlyKeyring;
 /**
  * Return the keyring instance. If it doesn't exist, create it.
  */
-async function getKeyring(): Promise<WatchOnlyKeyring> {
+export async function getKeyring(): Promise<WatchOnlyKeyring> {
   if (!keyring) {
     const state = await getState();
     if (!keyring) {
@@ -102,10 +102,19 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
     const validation = await validateUserInput(inputValue);
 
     if (validation.address) {
+      const { accountNameSuggestion } = validation;
       try {
-        await (
-          await getKeyring()
-        ).createAccount({ address: validation.address });
+        const createAccountOptions: {
+          address: string;
+          accountNameSuggestion?: string;
+        } = {
+          address: validation.address,
+        };
+        if (accountNameSuggestion) {
+          createAccountOptions.accountNameSuggestion = accountNameSuggestion;
+        }
+
+        await (await getKeyring()).createAccount({ ...createAccountOptions });
       } catch (error) {
         await showErrorMessage(id, (error as Error).message);
       }

--- a/src/keyring.test.ts
+++ b/src/keyring.test.ts
@@ -98,7 +98,7 @@ describe('WatchOnlyKeyring', () => {
   });
 
   describe('createAccount', () => {
-    it('should create a new account without options', async () => {
+    it('should create a new account with valid address', async () => {
       mockUuid.mockReturnValue('new-account-id');
       const expectedAccount = {
         id: 'new-account-id',
@@ -109,6 +109,22 @@ describe('WatchOnlyKeyring', () => {
       };
       const newAccount = await keyring.createAccount({
         address: mockAddress,
+      });
+      expect(newAccount).toStrictEqual(expectedAccount);
+    });
+
+    it('should create a new account with valid address and account name suggestion', async () => {
+      mockUuid.mockReturnValue('new-account-id');
+      const expectedAccount = {
+        id: 'new-account-id',
+        address: expect.any(String),
+        options: {},
+        methods: [],
+        type: 'eip155:eoa',
+      };
+      const newAccount = await keyring.createAccount({
+        address: mockAddress,
+        accountNameSuggestion: 'Watched Account 1',
       });
       expect(newAccount).toStrictEqual(expectedAccount);
     });

--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -41,7 +41,10 @@ export class WatchOnlyKeyring implements Keyring {
     );
   }
 
-  async createAccount(options: { address: string }): Promise<KeyringAccount> {
+  async createAccount(options: {
+    address: string;
+    accountNameSuggestion?: string;
+  }): Promise<KeyringAccount> {
     if (!options?.address) {
       throw new Error('Account creation options must include an address');
     }
@@ -66,7 +69,16 @@ export class WatchOnlyKeyring implements Keyring {
         methods: [],
         type: EthAccountType.Eoa,
       };
-      await this.#emitEvent(KeyringEvent.AccountCreated, { account });
+
+      const eventData: {
+        account: KeyringAccount;
+        accountNameSuggestion?: string;
+      } = { account };
+      if (options.accountNameSuggestion) {
+        eventData.accountNameSuggestion = options.accountNameSuggestion;
+      }
+
+      await this.#emitEvent(KeyringEvent.AccountCreated, { ...eventData });
       this.#state.wallets[account.id] = {
         account,
         privateKey: '', // Store an empty privateKey for watch-only accounts.

--- a/src/ui/ui-utils.test.ts
+++ b/src/ui/ui-utils.test.ts
@@ -10,6 +10,12 @@ global.ethereum = {
   request: jest.fn(),
 };
 
+// @ts-expect-error Mocking Snap global object
+global.snap = {
+  request: jest.fn(),
+  emitEvent: jest.fn(),
+};
+
 describe('UI Utils', () => {
   describe('isSmartContract', () => {
     it('should return true if the address has non-zero bytecode', async () => {
@@ -47,12 +53,6 @@ describe('UI Utils', () => {
     describe("when input starts with '0x'", () => {
       it('should return a valid address and message', async () => {
         const result = await validateUserInput(TEST_VALUES.validAddress);
-
-        jest.mock('./ui-utils', () => ({
-          ...jest.requireActual('./ui-utils'),
-          getNextAccountNumber: jest.fn().mockResolvedValueOnce(1),
-        }));
-
         expect(result).toStrictEqual({
           message: 'Valid address',
           address: TEST_VALUES.validAddress,

--- a/src/ui/ui-utils.test.ts
+++ b/src/ui/ui-utils.test.ts
@@ -47,9 +47,16 @@ describe('UI Utils', () => {
     describe("when input starts with '0x'", () => {
       it('should return a valid address and message', async () => {
         const result = await validateUserInput(TEST_VALUES.validAddress);
+
+        jest.mock('./ui-utils', () => ({
+          ...jest.requireActual('./ui-utils'),
+          getNextAccountNumber: jest.fn().mockResolvedValueOnce(1),
+        }));
+
         expect(result).toStrictEqual({
           message: 'Valid address',
           address: TEST_VALUES.validAddress,
+          accountNameSuggestion: 'Watched Account 1',
         });
       });
 
@@ -58,6 +65,7 @@ describe('UI Utils', () => {
         expect(result).toStrictEqual({
           message: `**${TEST_VALUES.validEns}**`,
           address: TEST_VALUES.validEnsAddress,
+          accountNameSuggestion: TEST_VALUES.validEns,
         });
       });
 
@@ -84,6 +92,7 @@ describe('UI Utils', () => {
         expect(result).toStrictEqual({
           message: formatAddress(TEST_VALUES.validEnsAddress),
           address: TEST_VALUES.validEnsAddress,
+          accountNameSuggestion: TEST_VALUES.validEns,
         });
       });
 


### PR DESCRIPTION
## Description

This PR will add an optional return value of an `accountNameSuggestion` to the `validateUserInput` utility function. The suggested name will be passed to the keyring `createAccount` method and emitted in the `"notify:accountCreated"`

Necessary for https://github.com/MetaMask/accounts-planning/issues/261