### PR TITLE
feat: changed button copy to 'Watch account'

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "rqYJtQC0GiTUGYgDyys6G4DxZEMZ6e8TyQ1w2LYHHeU=",
+    "shasum": "V0P9NS3MS1SrQTVYqKtr+9+Q3aVGwHedp6hcN3LX8d0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/ui/components/WatchForm.tsx
+++ b/src/ui/components/WatchForm.tsx
@@ -58,7 +58,7 @@ export const WatchForm: SnapComponent<WatchFormProps> = ({
             type={ButtonType.Submit}
             variant="primary"
           >
-            Watch
+            Watch account
           </Button>
         </Box>
       </Form>


### PR DESCRIPTION
## Description

Changed button copy from "Watch" to "Watch account" as per [latest designs](https://www.figma.com/design/Ym8Tw1CL02vCrjMok5kaUh/Account-Watcher?node-id=1-5045&t=xAJ2yd7Fo3KcaNSK-0)

Before
<img width="358" alt="Screenshot 2024-08-14 at 9 52 16 AM" src="https://github.com/user-attachments/assets/c08cf7f1-8cac-431f-88a4-d356f7f0d294">

After
<img width="353" alt="Screenshot 2024-08-14 at 9 53 00 AM" src="https://github.com/user-attachments/assets/8811eaa4-0d10-4d3f-903a-4f4a43d15350">
