### PR TITLE
chore: move deps from `dependencies` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,25 +41,21 @@
     "start": "mm-snap watch",
     "test": "yarn jest"
   },
-  "dependencies": {
+  "devDependencies": {
     "@ethereumjs/tx": "^5.1.0",
     "@ethereumjs/util": "^9.0.1",
-    "@metamask/keyring-api": "^8.1.3",
-    "@metamask/snaps-sdk": "^6.2.1",
-    "@metamask/utils": "^8.3.0",
-    "ethers": "^5.7.2",
-    "uuid": "^9.0.0"
-  },
-  "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.3",
     "@metamask/auto-changelog": "^3.3.0",
     "@metamask/eslint-config": "^12.2.0",
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
+    "@metamask/keyring-api": "^8.1.3",
     "@metamask/snaps-cli": "^6.2.1",
     "@metamask/snaps-jest": "^6.0.1",
+    "@metamask/snaps-sdk": "^6.2.1",
     "@metamask/snaps-types": "^3.1.0",
+    "@metamask/utils": "^8.3.0",
     "@types/jest": "^29.5.12",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.3.0",
@@ -74,11 +70,13 @@
     "eslint-plugin-n": "^16.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
+    "ethers": "^5.7.2",
     "jest": "^29.7.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.1.2",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "uuid": "^9.0.0"
   },
   "packageManager": "yarn@3.6.3",
   "engines": {


### PR DESCRIPTION
fixes: https://github.com/MetaMask/accounts-planning/issues/721