### PR TITLE
fix: returns `null` if `handleKeyringRequest` returns `undefined`/`void`

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "2oeQZTpv4uI6tH6SkBHhNHlhWPm6m1mwVJ6wXbyZNHU=",
+    "shasum": "ZAbpFY3gRQhEJ8hJvXht0i1gV2gOqQn7GO3Qb9Zg5B0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import type {
   OnHomePageHandler,
   OnUserInputHandler,
   OnKeyringRequestHandler,
-  Json,
 } from '@metamask/snaps-sdk';
 
 import { WatchOnlyKeyring } from './keyring';
@@ -59,7 +58,7 @@ export const onKeyringRequest: OnKeyringRequestHandler = async ({
   }
 
   // Handle keyring methods.
-  return (await handleKeyringRequest(await getKeyring(), request)) as Json;
+  return (await handleKeyringRequest(await getKeyring(), request)) ?? null;
 };
 
 /**


### PR DESCRIPTION
Since `handleKeyringRequest` might returns `void`, this would be evaluated to `undefined` which is not a valid value for the `Json` type. In this case, we returns `null`.