### PR TITLE
fix: use `displayConfirmation: false`

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metamask/snap-watch-only.git"
   },
   "source": {
-    "shasum": "ZAbpFY3gRQhEJ8hJvXht0i1gV2gOqQn7GO3Qb9Zg5B0=",
+    "shasum": "0jPKzSk3IbzDb+MqOXuh5nq7pGIyYnvg/EmSiKw5ITI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/keyring.ts
+++ b/src/keyring.ts
@@ -78,7 +78,12 @@ export class WatchOnlyKeyring implements Keyring {
         eventData.accountNameSuggestion = options.accountNameSuggestion;
       }
 
-      await this.#emitEvent(KeyringEvent.AccountCreated, { ...eventData });
+      await this.#emitEvent(KeyringEvent.AccountCreated, {
+        ...eventData,
+        // Since this will be used as preinstalled Snap, we don't want to show the
+        // intermediate confirmations.
+        displayConfirmation: false,
+      });
       this.#state.wallets[account.id] = {
         account,
         privateKey: '', // Store an empty privateKey for watch-only accounts.


### PR DESCRIPTION
We now need this flag to be set explicitly for preinstalled Snaps.

Requires:
- https://github.com/MetaMask/snap-watch-only/pull/57